### PR TITLE
Kireiev/sigma 1758/fix/add forgotten translations

### DIFF
--- a/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
@@ -11460,6 +11460,11 @@ msgstr ""
 msgid "You must agree to the {platform_name} {terms_of_service}"
 msgstr "Ви повинні прийняти пункт «{terms_of_service}» {platform_name}"
 
+#: extended_platform/overrides.py
+#, python-brace-format
+msgid "You must agree to the {platform_name} {terms_label}"
+msgstr "Ви повинні прийняти пункт {terms_label} {platform_name}"
+
 #: openedx/core/djangoapps/user_authn/views/registration_form.py:1045
 #, python-brace-format
 msgid ""

--- a/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
@@ -11461,6 +11461,7 @@ msgid "You must agree to the {platform_name} {terms_of_service}"
 msgstr "Ви повинні прийняти пункт «{terms_of_service}» {platform_name}"
 
 #: extended_platform/overrides.py
+#: openedx/core/djangoapps/user_authn/api/form_fields.py
 #, python-brace-format
 msgid "You must agree to the {platform_name} {terms_label}"
 msgstr "Ви повинні прийняти пункт {terms_label} {platform_name}"

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -180,5 +180,7 @@
   "register.page.terms.of.service": "Я погоджуюсь з {platformName} {termsOfService}",
   "sigma.login.other.options.heading": "Якщо Ви є співробітником Sigma Software, будь ласка, натисніть кнопку нижче і використовуйте свою корпоративну електронну пошту для входу.",
   "sso.label.login.text": "або",
-  "sso.label.register.text": "або створити обліковий запис тут"
+  "sso.label.register.text": "або створити обліковий запис тут",
+  "empty.tos.checkbox.error": "Ви маєте погодитися із {platformName} {termsOfService}",
+  "empty.privacy.policy.checkbox.error": "Ви маєте погодитися із {platformName} {privacyPolicy}"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -176,8 +176,8 @@
   "complete.your.profile.1": "Завершено",
   "complete.your.profile.2": "Ваш профіль",
   "register.page.terms.of.service.and.honor.code": "Створюючи аккаунт, ви погоджуєтесь з умовами {tosAndHonorCode}, і з тим, що {platformName}, та кожен учасник, використовує ваші персональні дані згідно {privacyPolicy}.",
-  "register.page.honor.code": "Я погоджуюсь з {platformName} {tosAndHonorCode}",
-  "register.page.terms.of.service": "Я погоджуюсь з {platformName} {termsOfService}",
+  "register.page.honor.code": "Я погоджуюсь з {tosAndHonorCode} {platformName}",
+  "register.page.terms.of.service": "Я погоджуюсь з {termsOfService} {platformName}",
   "sigma.login.other.options.heading": "Якщо Ви є співробітником Sigma Software, будь ласка, натисніть кнопку нижче і використовуйте свою корпоративну електронну пошту для входу.",
   "sso.label.login.text": "або",
   "sso.label.register.text": "або створити обліковий запис тут"

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -151,7 +151,7 @@
   "terms.of.service.and.honor.code": "Умови надання послуг та Кодекс Честі",
   "privacy.policy": "Політика Конфіденційності",
   "honor.code": "Кодекс Честі",
-  "terms.of.service": "Договір публічної оферти",
+  "terms.of.service": "Умови надання послуг",
   "registration.username.suggestion.label": "Рекомендовано:",
   "did.you.mean.alert.text": "Ви мали на увазі",
   "sign.in": "Увійти",

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -180,7 +180,5 @@
   "register.page.terms.of.service": "Я погоджуюсь з {platformName} {termsOfService}",
   "sigma.login.other.options.heading": "Якщо Ви є співробітником Sigma Software, будь ласка, натисніть кнопку нижче і використовуйте свою корпоративну електронну пошту для входу.",
   "sso.label.login.text": "або",
-  "sso.label.register.text": "або створити обліковий запис тут",
-  "empty.tos.checkbox.error": "Ви маєте погодитися із {platformName} {termsOfService}",
-  "empty.privacy.policy.checkbox.error": "Ви маєте погодитися із {platformName} {privacyPolicy}"
+  "sso.label.register.text": "або створити обліковий запис тут"
 }

--- a/translations/frontend-app-authn/src/i18n/transifex_input.json
+++ b/translations/frontend-app-authn/src/i18n/transifex_input.json
@@ -180,7 +180,5 @@
   "register.page.terms.of.service": "I agree to the {platformName} {termsOfService}",
   "sigma.login.other.options.heading": "If you are a Sigma Software employee, please press the button below and use your corporate email to sign in.",
   "sso.label.login.text": "or",
-  "sso.label.register.text": "or create a new one here",
-  "empty.tos.checkbox.error": "You must agree to the {platformName} {termsOfService}",
-  "empty.privacy.policy.checkbox.error": "You must agree to the {platformName} {privacyPolicy}"
+  "sso.label.register.text": "or create a new one here"
 }

--- a/translations/frontend-app-authn/src/i18n/transifex_input.json
+++ b/translations/frontend-app-authn/src/i18n/transifex_input.json
@@ -180,5 +180,7 @@
   "register.page.terms.of.service": "I agree to the {platformName} {termsOfService}",
   "sigma.login.other.options.heading": "If you are a Sigma Software employee, please press the button below and use your corporate email to sign in.",
   "sso.label.login.text": "or",
-  "sso.label.register.text": "or create a new one here"
+  "sso.label.register.text": "or create a new one here",
+  "empty.tos.checkbox.error": "You must agree to the {platformName} {termsOfService}",
+  "empty.privacy.policy.checkbox.error": "You must agree to the {platformName} {privacyPolicy}"
 }


### PR DESCRIPTION
**Description**

Added forgotten translation for Authn MFE, fixed existent translations for Authn MFE.

**YouTrack**

https://youtrack.raccoongang.com/issue/Sigma-1758/translations-Untranslated-strings-appeared