### PR TITLE
fix: footer translations

### DIFF
--- a/translations/ecommerce/ecommerce/conf/locale/es_419/LC_MESSAGES/django.po
+++ b/translations/ecommerce/ecommerce/conf/locale/es_419/LC_MESSAGES/django.po
@@ -4438,7 +4438,7 @@ msgstr "Este cliente aún no ha escrito ninguna evaluación."
 msgid "E-Commerce Service Administration"
 msgstr "Administración del servicio de E-commerce"
 
-msgid "About us"
+msgid "About"
 msgstr "Quiénes somos"
 
 msgid "Privacy Policy"
@@ -4447,5 +4447,5 @@ msgstr "Política de privacidad"
 msgid "Terms of Service"
 msgstr "Condiciones de Uso"
 
-msgid "Contact us"
+msgid "Contact Us"
 msgstr "Contáctenos"

--- a/translations/ecommerce/ecommerce/conf/locale/es_ES/LC_MESSAGES/django.po
+++ b/translations/ecommerce/ecommerce/conf/locale/es_ES/LC_MESSAGES/django.po
@@ -4438,7 +4438,7 @@ msgstr "Este cliente aún no ha escrito ninguna evaluación."
 msgid "E-Commerce Service Administration"
 msgstr "Administración del servicio de E-commerce"
 
-msgid "About us"
+msgid "About"
 msgstr "Quiénes somos"
 
 msgid "Privacy Policy"
@@ -4447,5 +4447,5 @@ msgstr "Política de privacidad"
 msgid "Terms of Service"
 msgstr "Condiciones de Uso"
 
-msgid "Contact us"
+msgid "Contact Us"
 msgstr "Contáctenos"

--- a/translations/ecommerce/ecommerce/conf/locale/pt_PT/LC_MESSAGES/django.po
+++ b/translations/ecommerce/ecommerce/conf/locale/pt_PT/LC_MESSAGES/django.po
@@ -4424,7 +4424,7 @@ msgstr "Este cliente ainda não escreveu comentários."
 msgid "E-Commerce Service Administration"
 msgstr "Administração do Serviço E-Commerce"
 
-msgid "About Us"
+msgid "About"
 msgstr "Quem Somos"
 
 msgid "Contact Us"


### PR DESCRIPTION
YT:
- https://youtrack.raccoongang.com/issue/DR-263/E-commerce-The-Spanish-Portuguese-translations-are-missing-for-the-titles-of-the-static-pages-on-the-e-commerce-legacy-pages