### PR TITLE
fix: [Sigma-1869] Fix datetime format for uk

### DIFF
--- a/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/uk/LC_MESSAGES/django.po
@@ -1093,7 +1093,7 @@ msgstr "Будь ласка, зачекайте"
 #. See http://strftime.org for details.
 #: common/djangoapps/util/date_utils.py:145
 msgid "LONG_DATE_FORMAT"
-msgstr "ДОВГИЙ_ФОРМАТ_ДАТИ"
+msgstr "%A, %B %d %Y"
 
 #. Translators: the translation for "DATE_TIME_FORMAT" must be a format
 #. string for formatting dates with times.  For example, the American
@@ -1101,7 +1101,7 @@ msgstr "ДОВГИЙ_ФОРМАТ_ДАТИ"
 #. See http://strftime.org for details.
 #: common/djangoapps/util/date_utils.py:153
 msgid "DATE_TIME_FORMAT"
-msgstr "ЧАСОВИЙ_ФОРМАТ_ДАТИ"
+msgstr "%d %b %Y %H:%M"
 
 #. Translators: the translation for "SHORT_DATE_FORMAT" must be a
 #. format string for formatting dates in a brief form.  For example,
@@ -1109,14 +1109,14 @@ msgstr "ЧАСОВИЙ_ФОРМАТ_ДАТИ"
 #. See http://strftime.org for details.
 #: common/djangoapps/util/date_utils.py:189
 msgid "SHORT_DATE_FORMAT"
-msgstr "КОРОТКИЙ_ФОРМАТ_ДАТИ"
+msgstr "%b %d %Y"
 
 #. Translators: the translation for "TIME_FORMAT" must be a format
 #. string for formatting times.  For example, the American English
 #. form is "%H:%M:%S". See http://strftime.org for details.
 #: common/djangoapps/util/date_utils.py:201
 msgid "TIME_FORMAT"
-msgstr "ФОРМАТ_ЧАСУ"
+msgstr "%H:%M:%S"
 
 #. Translators: This is an AM/PM indicator for displaying times.  It is
 #. used for the %p directive in date-time formats. See http://strftime.org


### PR DESCRIPTION
**Description**

Fixed the wrong Date format appeared for the uk language.

**YouTrack**

https://youtrack.raccoongang.com/issue/Sigma-1869/notestranslations-The-Wrong-Date-format-appeared-on-the-Notes-page