### PR TITLE
fix: add missing fr_CA translation for Profile MFE component

### DIFF
--- a/translations/frontend-app-profile/src/i18n/messages/fr_CA.json
+++ b/translations/frontend-app-profile/src/i18n/messages/fr_CA.json
@@ -1,5 +1,6 @@
 {
   "profile.page.title": "Profil | {siteName}",
+  "profile.age.headline": "Votre profil ne peut pas être partagé.",
   "profile.age.details": "Pour partager votre profil avec d'autres apprenants {siteName}, vous devez confirmer que vous avez plus de 13 ans.",
   "profile.age.set.date": "Entrez votre date de naissance",
   "profile.datejoined.member.since": "Membre depuis {year}",

--- a/translations/frontend-app-profile/src/i18n/transifex_input.json
+++ b/translations/frontend-app-profile/src/i18n/transifex_input.json
@@ -1,5 +1,6 @@
 {
   "profile.page.title": "Profile | {siteName}",
+  "profile.age.headline": "Your profile cannot be shared.",
   "profile.age.details": "To share your profile with other {siteName} learners, you must confirm that you are over the age of 13.",
   "profile.age.set.date": "Set your date of birth",
   "profile.datejoined.member.since": "Member since {year}",


### PR DESCRIPTION
<img width="3268" height="1418" alt="image" src="https://github.com/user-attachments/assets/bb6d9ff1-6d11-42c5-882f-9367499c6226" />
