### PR TITLE
fix: [HARROW_6-4133] add "View Content" translation to djangojs.po

### DIFF
--- a/translations/edx-platform/conf/locale/en/LC_MESSAGES/djangojs.po
+++ b/translations/edx-platform/conf/locale/en/LC_MESSAGES/djangojs.po
@@ -9644,7 +9644,7 @@ msgstr ""
 
 #: lms/templates/learner_dashboard/course_enroll.underscore:7
 msgid "View Course"
-msgstr ""
+msgstr "View Content"
 
 #: lms/templates/learner_dashboard/course_enroll.underscore:15
 msgid "Select a session:"


### PR DESCRIPTION
## Summary

- Add `msgstr "View Content"` for `msgid "View Course"` in `djangojs.po` (`en` locale)
- The previous PR #97 added this translation only to `django.po` (Python/API side) but missed `djangojs.po` (JavaScript `gettext` side)
- Without this, `course_enroll.underscore` renders "View Course" instead of "View Content" because JS `gettext` reads from `djangojs.po`

## Ticket

- [HARROW_6-4133](https://youtrack.raccoongang.com/issue/HARROW_6-4133/FE-i18n-compatibility) -- [FE] i18n compatibility