### PR TITLE
feat: brand-safe zh_CN backfill wave 2 (learner-dashboard)

### DIFF
--- a/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-learner-dashboard/src/i18n/messages/zh_CN.json
@@ -152,5 +152,18 @@
   "learner-dash.courseCard.banners.credit.rejected": "{providerName}未批准您的课程学分请求。欲了解更多信息，请直接联系{linkToProviderSite} 。",
   "learner-dash.courseCard.banners.credit.requestCredit": "申请学分",
   "learner-dash.courseCard.banners.credit.viewCredit": "查看认证",
-  "learner-dash.courseCard.banners.credit.viewDetails": "查看详情"
+  "learner-dash.courseCard.banners.credit.viewDetails": "查看详情",
+  "learner-dash.unenrollConfirm.reasons.prereqs": "我不具备学术或语言方面的先决条件",
+  "learner-dash.unenrollConfirm.reasons.difficulty": "课程材料太难理解了。",
+  "learner-dash.unenrollConfirm.reasons.goals": "这不会帮助我实现我的目标",
+  "learner-dash.unenrollConfirm.reasons.broken": "有东西坏了",
+  "learner-dash.unenrollConfirm.reasons.time": "我没有时间",
+  "learner-dash.unenrollConfirm.reasons.browse": "我只是想浏览一下资料",
+  "learner-dash.unenrollConfirm.reasons.support": "我没有足够的支持",
+  "learner-dash.unenrollConfirm.reasons.quality": "我对内容的质量不满意",
+  "learner-dash.unenrollConfirm.reasons.easy": "课程材料太简单",
+  "learner-dash.unenrollConfirm.reasons.custom-placeholder": "其他",
+  "learner-dash.unenrollConfirm.reasons.prefer-not-to-say": "我不想说",
+  "learner-dash.unenrollConfirm.confirm.text": "你確定要退出課程 {courseTitle} 嗎？",
+  "learner-dash.page.title": "學習者主頁 | {siteName}"
 }


### PR DESCRIPTION
## Summary
Brand-safe zh_CN backfill **wave 2** — covers the deployed MFEs not touched by the open PRs #100/#101/#103 (to stay conflict-free). Same brand-guard as PR #103: fill only where fork en == upstream en; skip anything containing edX brand tokens.

| Component | Added keys | Notes |
|---|---|---|
| `frontend-app-learner-dashboard` | **13** | unenroll-confirmation reasons (11), confirm text, page title. Catalog 144 → 157 keys. ⚠ 2 values arrived in Traditional Chinese from upstream (`unenrollConfirm.confirm.text`, `page.title`) — flagged for native review |
| `frontend-app-ora-grading` | 0 | 2 candidate keys skipped: fork en ≠ upstream en and no upstream zh (brand-safe rule) |

## Inventory (why so small)
Full per-component audit of the 12 deployed translation components: the remaining empty/missing keys live in components already covered by open PRs (#100: account/authn/communications/discussions/gradebook/profile/header/footer; #103: course-authoring/learning). Biggest residual is **catalog lag vs upstream** (course-authoring −1208 keys, learning −316) — that requires a fork re-sync pass **after** the open PRs merge, tracked in [HARROW_6-4568](https://youtrack.raccoongang.com/issue/HARROW_6-4568).

## Verification
Build-time inlined → verify on harrowcn-dev after learner-dashboard MFE rebuild.

## YouTrack
- [HARROW_6-4568](https://youtrack.raccoongang.com/issue/HARROW_6-4568)

