### PR TITLE
fix: add missing zh_CN msgids (course search, CMS 404)

### DIFF
--- a/translations/edx-platform/conf/locale/zh_CN/LC_MESSAGES/django.po
+++ b/translations/edx-platform/conf/locale/zh_CN/LC_MESSAGES/django.po
@@ -22054,3 +22054,8 @@ msgstr[0] "查看 %s 门课程"
 
 msgid "Role type"
 msgstr "角色类型"
+
+#: cms/templates/404.html:20
+#, python-brace-format
+msgid "Go back to the {homepage}."
+msgstr "返回{homepage}。"

--- a/translations/edx-platform/conf/locale/zh_CN/LC_MESSAGES/djangojs.po
+++ b/translations/edx-platform/conf/locale/zh_CN/LC_MESSAGES/djangojs.po
@@ -9635,3 +9635,9 @@ msgstr "对不起，未找到搜索结果。"
 #: cms/templates/js/add-xblock-component-button.underscore:10
 msgid "Beta"
 msgstr "测试版"
+
+#: lms/static/js/discovery/views/search_form.js:47
+#, javascript-format
+msgid "Viewing %s course"
+msgid_plural "Viewing %s courses"
+msgstr[0] "正在查看 %s 门课程"


### PR DESCRIPTION
## Summary
Adds 2 missing zh_CN msgids to the fork's edx-platform catalogs (audit IDs L-028, AD-008). Additions only — no existing entries touched. `msgfmt --check` passes on both files.

| Audit ID | msgid | File | zh |
|---|---|---|---|
| L-028 | `Viewing %s course` / plural `Viewing %s courses` (`search_form.js:47`) | `zh_CN/LC_MESSAGES/djangojs.po` | 正在查看 %s 门课程 |
| AD-008 | `Go back to the {homepage}.` (`cms/templates/404.html:20`) | `zh_CN/LC_MESSAGES/django.po` | 返回{homepage}。 |

Note: the plural pair already existed in zh_CN **django.po** but was absent from **djangojs.po**, which is where `search_form.js` actually resolves — that was the real gap.

**L-057 intentionally NOT included:** "Professional Certificate" on the program progress page is a program-**type data value** interpolated into the already-translated `{type} Progress` wrapper (`{type}进度`) — there is no missing msgid; needs a data-level fix (Discovery program type), not a catalog entry.

## Verification
Takes effect after openedx image rebuild (ATLAS re-pull + compilemessages). Check the course search page (zh-cn) and the Studio 404 page.

## YouTrack
- [HARROW_6-4594](https://youtrack.raccoongang.com/issue/HARROW_6-4594)

