### PR TITLE
feat: [HARROW_6-4773] add course feedback modal translations (zh_CN)

### DIFF
--- a/translations/frontend-app-learning/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-learning/src/i18n/messages/zh_CN.json
@@ -493,5 +493,16 @@
   "upgrade.open.button": "显示升级面板",
   "upgrade.responsive.close.button": "返回课程",
   "upgrade.title": "升级",
-  "upgrade.no.message": "暂无可用升级选项。"
+  "upgrade.no.message": "暂无可用升级选项。",
+  "learning.courseFeedback.title": "您如何评价这门课程？",
+  "learning.courseFeedback.ratingPrompt": "请为您的体验评分，帮助我们改进。",
+  "learning.courseFeedback.commentPrompt": "请在下方分享任何其他反馈。",
+  "learning.courseFeedback.commentPlaceholder": "告诉我们哪些做得好，或哪些可以改进。",
+  "learning.courseFeedback.ratingGroupLabel": "课程评分",
+  "learning.courseFeedback.starLabel": "{count} 星",
+  "learning.courseFeedback.exit": "退出课程",
+  "learning.courseFeedback.submit": "提交",
+  "learning.courseFeedback.submitting": "正在提交……",
+  "learning.courseFeedback.errorGeneric": "出现错误，请重试。",
+  "learning.courseFeedback.characterCount": "{current}/{max}"
 }

--- a/translations/frontend-app-learning/src/i18n/transifex_input.json
+++ b/translations/frontend-app-learning/src/i18n/transifex_input.json
@@ -480,5 +480,16 @@
   "courseOutline.tray.title": "Course outline",
   "courseOutline.completedUnit": "Completed unit",
   "courseOutline.incompleteUnit": "Incomplete unit",
-  "discussions.sidebar.open.button": "Show discussions tray"
+  "discussions.sidebar.open.button": "Show discussions tray",
+  "learning.courseFeedback.title": "How would you rate this course?",
+  "learning.courseFeedback.ratingPrompt": "Please rate your experience to help us improve.",
+  "learning.courseFeedback.commentPrompt": "Please share any additional feedback below.",
+  "learning.courseFeedback.commentPlaceholder": "Tell us what worked or what could be improved.",
+  "learning.courseFeedback.ratingGroupLabel": "Course rating",
+  "learning.courseFeedback.starLabel": "{count, plural, one {# star} other {# stars}}",
+  "learning.courseFeedback.exit": "Exit course",
+  "learning.courseFeedback.submit": "Submit",
+  "learning.courseFeedback.submitting": "Submitting…",
+  "learning.courseFeedback.errorGeneric": "Something went wrong. Please try again.",
+  "learning.courseFeedback.characterCount": "{current}/{max}"
 }


### PR DESCRIPTION
## Description

Adds the user-facing strings for the course feedback modal — the prompt that asks learners to rate a course — including their Simplified Chinese (zh_CN) translations. This ensures the rating dialog (title, rating prompt, comment field, star labels, submit/exit buttons, and error messages) displays in the correct language for learners using the Chinese locale.

## Youtrack

- https://youtrack.raccoongang.com/issue/HARROW_6-4773

## Screenshot/Video

<img width="501" height="532" alt="image" src="https://github.com/user-attachments/assets/f67899ba-669b-448f-b22d-dc56d5586b00" />