### PR TITLE
feat: [HARROW_6-4627] Course Feedback Studio app strings (EN + zh_CN)

### DIFF
--- a/translations/frontend-app-course-authoring/src/i18n/messages/zh_CN.json
+++ b/translations/frontend-app-course-authoring/src/i18n/messages/zh_CN.json
@@ -2931,5 +2931,8 @@
   "course-authoring.pages-resources.app-settings-modal.reset-all-units": "重置所有单元",
   "course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip.checked": "立即重置任何单元级别的更改并检查所有单元上的“启用摘要”。",
   "course-authoring.pages-resources.app-settings-modal.reset-all-units-tooltip.unchecked": "立即重置所有单元级别的更改和取消选中的所有单元上的“启用摘要”。",
-  "course-authoring.pages-resources.app-settings-modal.reset": "重置"
+  "course-authoring.pages-resources.app-settings-modal.reset": "重置",
+  "course-authoring.pages-resources.course-feedback.heading": "配置课程反馈",
+  "course-authoring.pages-resources.course-feedback.enable.label": "课程反馈",
+  "course-authoring.pages-resources.course-feedback.enable.help": "当学习者通过课程时向其显示简短的满意度弹窗，收集评分和可选评论。"
 }

--- a/translations/frontend-app-course-authoring/src/i18n/transifex_input.json
+++ b/translations/frontend-app-course-authoring/src/i18n/transifex_input.json
@@ -1741,5 +1741,8 @@
   "course-authoring.studio-home.add-new-library.btn.text": "New library",
   "course-authoring.studio-home.taxonomies.tab.title": "Taxonomies",
   "course-authoring.studio-home.legacy.libraries.tab.title": "Legacy Libraries",
-  "course-authoring.studio-home.libraries.tab.library.not.found.alert.title": "We could not find any result"
+  "course-authoring.studio-home.libraries.tab.library.not.found.alert.title": "We could not find any result",
+  "course-authoring.pages-resources.course-feedback.heading": "Configure Course Feedback",
+  "course-authoring.pages-resources.course-feedback.enable.label": "Course Feedback",
+  "course-authoring.pages-resources.course-feedback.enable.help": "Show a short satisfaction pop-up to learners when they pass the course, collecting a rating and an optional comment."
 }


### PR DESCRIPTION
## Summary

Adds the Chinese (zh_CN) translations for the **Course Feedback** Course App shown in Studio → Pages & Resources (the Harrow `frontend-build` authoring override). Source (EN) strings added to `transifex_input.json`, translations to `messages/zh_CN.json` for `frontend-app-course-authoring`.

New message ids:
- `course-authoring.pages-resources.course-feedback.heading` — Configure Course Feedback / 配置课程反馈
- `course-authoring.pages-resources.course-feedback.enable.label` — Course Feedback / 课程反馈
- `course-authoring.pages-resources.course-feedback.enable.help` — … / 当学习者通过课程时向其显示简短的满意度弹窗，收集评分和可选评论。

Mirrors PR #109 (which added the learning-MFE modal strings). Applied to Studio via ATLAS on the next authoring-MFE build.

## Related
- Feature: https://youtrack.raccoongang.com/issue/HARROW_6-4630
- Studio config (FE): https://youtrack.raccoongang.com/issue/HARROW_6-4627 — frontend-build !37