### PR TITLE
fix: [COPER-903] override authn register consent text (en/uk/pl)

### DIFF
--- a/translations/frontend-app-authn/src/i18n/messages/pl.json
+++ b/translations/frontend-app-authn/src/i18n/messages/pl.json
@@ -175,7 +175,7 @@
   "welcome.to.platform": "Witamy w {siteName} , {fullName} !",
   "complete.your.profile.1": "Kompletny",
   "complete.your.profile.2": "Twój profil",
-  "register.page.terms.of.service.and.honor.code": "Tworząc konto, wyrażasz zgodę na {tosAndHonorCode} i potwierdzasz, że {platformName} i każdy Członek przetwarzają Twoje dane osobowe zgodnie z {privacyPolicy} .",
+  "register.page.terms.of.service.and.honor.code": "Zakładając konto, użytkownik wyraża zgodę na {tosAndHonorCode} i przyjmuje do wiadomości, że {platformName} przetwarza jego dane osobowe zgodnie z {privacyPolicy}.",
   "register.page.honor.code": "Zgadzam się z {platformName} {tosAndHonorCode}",
   "register.page.terms.of.service": "Zgadzam się z {platformName} {termsOfService}"
 }

--- a/translations/frontend-app-authn/src/i18n/messages/uk.json
+++ b/translations/frontend-app-authn/src/i18n/messages/uk.json
@@ -175,7 +175,7 @@
   "welcome.to.platform": "Ласкаво просимо до {siteName} , {fullName} !",
   "complete.your.profile.1": "Завершено",
   "complete.your.profile.2": "Ваш профіль",
-  "register.page.terms.of.service.and.honor.code": "Створюючи аккаунт, ви погоджуєтесь з умовами {tosAndHonorCode}, і з тим, що {platformName}, та кожен учасник, використовує ваші персональні дані згідно {privacyPolicy}.",
+  "register.page.terms.of.service.and.honor.code": "Створюючи обліковий запис, ви приймаєте {tosAndHonorCode} та визнаєте, що {platformName} оброблює ваші персональні дані відповідно до {privacyPolicy}.",
   "register.page.honor.code": "Я погоджуюсь з {platformName}&nbsp;{tosAndHonorCode}",
   "register.page.terms.of.service": "Я погоджуюсь з {platformName}&nbsp;{termsOfService}"
 }

--- a/translations/frontend-app-authn/src/i18n/transifex_input.json
+++ b/translations/frontend-app-authn/src/i18n/transifex_input.json
@@ -175,7 +175,7 @@
   "welcome.to.platform": "Welcome to {siteName}, {fullName}!",
   "complete.your.profile.1": "Complete",
   "complete.your.profile.2": "your profile",
-  "register.page.terms.of.service.and.honor.code": "By creating an account, you agree to the {tosAndHonorCode} and you acknowledge that {platformName} and each Member process your personal data in accordance with the {privacyPolicy}.",
+  "register.page.terms.of.service.and.honor.code": "By creating an account, you agree to the {tosAndHonorCode} and you acknowledge that {platformName} process your personal data in accordance with the {privacyPolicy}.",
   "register.page.honor.code": "I agree to the {platformName}&nbsp;{tosAndHonorCode}",
   "register.page.terms.of.service": "I agree to the {platformName}&nbsp;{termsOfService}"
 }


### PR DESCRIPTION
## What

The register-page legal consent text rendered by the authn MFE (`register.page.terms.of.service.and.honor.code`) still used the upstream default wording — "…{platformName} **and each Member process** your personal data…". tutor-copernicus !10 made the field render but did not override the string itself, so QA returned COPER-903.

The correct Copernicus wording lived only in the Nutmeg `extended-translations` Django `.po` catalog; on the Teak upgrade the register page moved to the authn MFE (different message format) and the wording was never carried over. This PR ports it into the atlas-pulled authn i18n for the three project languages:

- **en** (`transifex_input.json`): drop "and each Member".
- **uk** (`messages/uk.json`): replace the stock string (still had "та кожен учасник … використовує") with the prod/Nutmeg wording ("оброблює", no third party).
- **pl** (`messages/pl.json`, new): add the prod/Nutmeg Polish wording (this catalog had no `pl.json` before — only this key is provided; the rest of authn still falls back to English for Polish).

Wording matches the client prod screenshots.

## Verify

After the authn MFE is rebuilt with `atlas pull` (coper-main):

```
URL: https://copernicus-college-teak-dev.raccoongang.net/authn/register
STR: open the Register page, scroll under the form
ER (en): "By creating an account, you agree to the Terms of Service and Honor Code and you
          acknowledge that Copernicus College process your personal data in accordance with
          the Privacy Policy." — no "and each Member"
ER (uk/pl): translated line without "кожен учасник" / "Member"
```

## Risks

- **Prod ↔ AC delta:** wording matches client prod (`…College process your personal data…`, no comma). The COPER-903 AC example instead reads `…College, … processes…`. Kept prod wording deliberately; one-word/comma change if QA prefers the AC.
- **Polish partial:** authn had no `pl.json`; only the consent key is translated, remaining authn strings still render in English for Polish users (pre-existing gap, out of scope).

## Related MRs

- `tutor-copernicus` -- [!10](https://gitlab.raccoongang.com/Duck-Team/projects/copernicus-college/teak/tutor-copernicus/-/merge_requests/10) ✅ merged -- enables the honor_code field so the consent text renders

## Ticket

- [COPER-903](https://youtrack.raccoongang.com/issue/COPER-903) -- [LMS] Register page. The mandatory legal consent text is missing under the Register form