### PR TITLE
feat: [VSO-47] add missing RGG uk translations

### DIFF
--- a/translations/edx-gamma-dashboard/course_leaderboard/conf/locale/uk/LC_MESSAGES/django.po
+++ b/translations/edx-gamma-dashboard/course_leaderboard/conf/locale/uk/LC_MESSAGES/django.po
@@ -1,0 +1,20 @@
+# edX translation file
+# Copyright (C) 2026 RaccoonGang
+# This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: edx-gamma-dashboard\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-05 00:00+0000\n"
+"PO-Revision-Date: 2026-08-05 00:00+0000\n"
+"Language-Team: Ukrainian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+
+#: course_leaderboard/tab.py:16
+msgid "Course Leaderboard"
+msgstr "Таблиця лідерів курсу"

--- a/translations/edx-gamma-dashboard/gamma_dashboard/conf/locale/uk/LC_MESSAGES/django.po
+++ b/translations/edx-gamma-dashboard/gamma_dashboard/conf/locale/uk/LC_MESSAGES/django.po
@@ -1,0 +1,24 @@
+# edX translation file
+# Copyright (C) 2026 RaccoonGang
+# This file is distributed under the GNU AFFERO GENERAL PUBLIC LICENSE.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: edx-gamma-dashboard\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-05 00:00+0000\n"
+"PO-Revision-Date: 2026-08-05 00:00+0000\n"
+"Language-Team: Ukrainian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+
+#: gamma_dashboard/dashboard/api/v0/views.py:39
+msgid "Gamma Leaderboard is disabled."
+msgstr "Таблиця лідерів вимкнена."
+
+#: gamma_dashboard/dashboard/api/v0/views.py:101
+msgid "Gamma Dashboard is disabled."
+msgstr "Дашборд продуктивності вимкнено."

--- a/translations/frontend-component-header/src/i18n/messages/uk.json
+++ b/translations/frontend-component-header/src/i18n/messages/uk.json
@@ -22,6 +22,8 @@
   "header.label.secondary.nav": "Середня",
   "header.label.skip.nav": "Перейти до головного змісту",
   "header.label.app.nav": "Додаток",
+  "header.menu.performance.label": "Продуктивність",
+  "header.menu.leaderboard.label": "Таблиця лідерів",
   "general.register.sentenceCase": "Зареєструватися",
   "general.signIn.sentenceCase": "Увійти",
   "header.menu.dashboard.label": "Мої курси",


### PR DESCRIPTION
- frontend-component-header: header.menu.performance.label / header.menu.leaderboard.label
- edx-gamma-dashboard: course_leaderboard tab title, gamma_dashboard disabled-API error strings